### PR TITLE
Slack API IM methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ is subject to frequent change._
  - chat.delete
  - chat.postMessage
  - chat.update
+ - im.close
+ - im.history
+ - im.list
+ - im.mark
+ - im.open
 
 ## Download
 

--- a/src/main/scala/com/flyberrycapital/slack/Methods/IM.scala
+++ b/src/main/scala/com/flyberrycapital/slack/Methods/IM.scala
@@ -1,0 +1,181 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.flyberrycapital.slack.Methods
+
+import com.flyberrycapital.slack.{HttpClient, SlackIM, SlackMessage}
+import org.joda.time.DateTime
+import play.api.libs.json.{JsObject, JsValue}
+
+/**
+ * The container for Slack's 'im' methods (https://api.slack.com/methods).
+ *
+ * <i>Note: This is a partial implementation, and some (i.e. most) methods are unimplemented.</i>
+ */
+class IM(httpClient: HttpClient, apiToken: String) {
+
+   import com.flyberrycapital.slack.Responses._
+
+   /**
+    * https://api.slack.com/methods/im.close
+    *
+    * @param channel The channel ID for the direct message history to close.
+    * @return IMCloseResponse
+    */
+   def close(channel: String): IMCloseResponse = {
+      val params = Map("channel" -> channel, "token" -> apiToken)
+
+      val responseDict = httpClient.get("im.close", params)
+
+      IMCloseResponse(
+         (responseDict \ "ok").as[Boolean],
+         (responseDict \ "no_op").asOpt[Boolean].getOrElse(false),
+         (responseDict \ "already_closed").asOpt[Boolean].getOrElse(false)
+      )
+   }
+
+   /**
+    * https://api.slack.com/methods/im.history
+    *
+    * The format is exactly the same as channels.history, with the exception that we call im.history.
+    * Code copied from [[com.flyberrycapital.slack.Methods.Channels]]
+    *
+    * @param channel The channel ID of the IM to get history for.
+    * @param params A map of optional parameters and their values.
+    * @return ChannelHistoryResponse
+    */
+   def history(channel: String, params: Map[String, String] = Map()): ChannelHistoryResponse = {
+      val cleanedParams = params + ("channel" -> channel, "token" -> apiToken)
+
+      val responseDict = httpClient.get("im.history", cleanedParams)
+
+      val messages = (responseDict \ "messages").as[List[JsObject]] map { (x) =>
+         val user = Option((x \ "user").asOpt[String]
+            .getOrElse((x \ "user").asOpt[String]
+            .getOrElse(null)))
+
+         SlackMessage(
+            (x \ "type").as[String],
+            (x \ "ts").as[String],
+            user,
+            (x \ "text").asOpt[String],
+            (x \ "is_starred").asOpt[Boolean].getOrElse(false),
+            (x \ "attachments").asOpt[List[JsValue]].getOrElse(List()),
+            new DateTime(((x \ "ts").as[String].toDouble * 1000).toLong)
+         )
+      }
+
+      ChannelHistoryResponse(
+         (responseDict \ "ok").as[Boolean],
+         messages,
+         (responseDict \ "has_more").asOpt[Boolean].getOrElse(false),
+         (responseDict \ "is_limited").asOpt[Boolean].getOrElse(false)
+      )
+   }
+
+   /**
+    * A wrapper around the im.history method that allows users to stream through a channel's past messages
+    * seamlessly without having to worry about pagination and multiple queries.
+    *
+    * @param channel The channel ID to fetch history for.
+    * @param params A map of optional parameters and their values.
+    * @return Iterator of SlackMessages, ordered by time in descending order.
+    */
+   def historyStream(channel: String, params: Map[String, String] = Map()): Iterator[SlackMessage] = {
+      new Iterator[SlackMessage] {
+         var hist = history(channel, params = params)
+         var messages = hist.messages
+
+         def hasNext = messages.nonEmpty
+
+         def next() = {
+            val m = messages.head
+            messages = messages.tail
+
+            if (messages.isEmpty && hist.hasMore) {
+               hist = history(channel, params = params + ("latest" -> m.ts))
+               messages = hist.messages
+            }
+
+            m
+         }
+      }
+   }
+
+   /**
+    * https://api.slack.com/methods/im.list
+    *
+    * @return IMListResponse of all open IM channels
+    */
+   def list(): IMListResponse = {
+      val params = Map("token" -> apiToken)
+
+      val responseDict = httpClient.get("im.list", params)
+
+      val ims = (responseDict \ "ims").as[List[JsObject]] map { (im) =>
+         SlackIM(
+            (im \ "id").as[String],
+            (im \ "user").as[String],
+            (im \ "created").as[Int],
+            (im \ "is_user_deleted").as[Boolean]
+         )
+      }
+      IMListResponse(
+         (responseDict \ "ok").as[Boolean],
+         ims
+      )
+   }
+
+   /**
+    * https://api.slack.com/methods/im.mark
+    *
+    * @param channel The channel ID for the direct message history to set reading cursor in.
+    * @param params ts Timestamp of the most recently seen message.
+    * @return IMMarkResponse
+    */
+   def mark(channel: String, ts: String): IMMarkResponse = {
+      val params = Map("channel" -> channel, "ts" -> ts, "token" -> apiToken)
+
+      val responseDict = httpClient.get("im.mark", params)
+
+      IMMarkResponse(
+         (responseDict \ "ok").as[Boolean]
+      )
+   }
+
+   /**
+    * https://api.slack.com/methods/im.open
+    *
+    * @param user The user ID for the user to open a direct message channel with.
+    * @return IMOpenResponse
+    */
+   def open(user: String): IMOpenResponse = {
+      val params = Map("user" -> user, "token" -> apiToken)
+
+      val responseDict = httpClient.get("im.open", params)
+
+      IMOpenResponse(
+         (responseDict \ "ok").as[Boolean],
+         (responseDict \ "channel" \ "id").as[String],
+         (responseDict \ "no_op").asOpt[Boolean].getOrElse(false),
+         (responseDict \ "already_open").asOpt[Boolean].getOrElse(false)
+      )
+   }
+
+}

--- a/src/main/scala/com/flyberrycapital/slack/Responses.scala
+++ b/src/main/scala/com/flyberrycapital/slack/Responses.scala
@@ -36,5 +36,12 @@ object Responses {
    case class APITestResponse(ok: Boolean, args: Option[Map[String, String]]) extends SlackResponse
    case class ChannelHistoryResponse(ok: Boolean, messages: List[SlackMessage],
                                      hasMore: Boolean, isLimited: Boolean)
-   case class ChannelListResponse(ok: Boolean, channels: List[SlackChannel])
+   case class ChannelListResponse(ok: Boolean, channels: List[SlackChannel]) extends SlackResponse
+   case class IMCloseResponse(ok: Boolean, no_op: Boolean, already_closed: Boolean) extends SlackResponse
+   case class IMMarkResponse(ok: Boolean) extends SlackResponse
+   case class IMOpenResponse(ok: Boolean, channelId: String, no_op: Boolean, 
+                             already_open: Boolean) extends SlackResponse
+   case class IMListResponse(ok: Boolean, ims: List[SlackIM]) extends SlackResponse
+   case class IMHistoryResponse(ok: Boolean, messages: List[SlackMessage], 
+                                hasMore: Boolean, isLimited: Boolean)
 }

--- a/src/main/scala/com/flyberrycapital/slack/SlackIM.scala
+++ b/src/main/scala/com/flyberrycapital/slack/SlackIM.scala
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014 Flyberry Capital, LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +21,12 @@
 
 package com.flyberrycapital.slack
 
-
 /**
- * A simple Scala client for Slack (http://slack.com/).
- *
- * @param apiToken Your Slack API token (https://api.slack.com/).
+ * Class for representing a Slack IM channel.
+ * 
+ * @param id The IM channel ID.
+ * @param user The user ID of the "calling user"
+ * @param created A UNIX timestamp corresponding to the IM creation data/time.
+ * @param is_user_deleted Denotes if the other user's account has been disabled.
  */
-class SlackClient(private val apiToken: String) {
-
-   protected val BASE_URL = "https://slack.com/api"
-
-   protected val httpClient = new HttpClient()
-
-   import com.flyberrycapital.slack.Methods._
-
-   val api = new API(httpClient, apiToken)
-   val auth = new Auth(httpClient, apiToken)
-   val channels = new Channels(httpClient, apiToken)
-   val chat = new Chat(httpClient, apiToken)
-   val im = new IM(httpClient, apiToken)
-}
+case class SlackIM(id: String, user: String, created: Int, is_user_deleted: Boolean)

--- a/src/test/scala/IMSpec.scala
+++ b/src/test/scala/IMSpec.scala
@@ -1,0 +1,245 @@
+/*
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.flyberrycapital.slack.HttpClient
+import com.flyberrycapital.slack.Methods.IM
+import org.joda.time.{DateTimeZone, DateTime}
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import play.api.libs.json.Json
+
+
+class IMSpec extends FlatSpec with MockitoSugar with Matchers with BeforeAndAfterEach {
+
+   private val testApiKey = "TEST_API_KEY"
+
+   private var mockHttpClient: HttpClient = _
+   var im : IM = _
+
+   override def beforeEach() {
+      mockHttpClient = mock[HttpClient]
+      when(mockHttpClient.get("im.close", Map("channel" -> "D12345", "token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |   "ok": true
+           |}
+         """.stripMargin))
+
+      when(mockHttpClient.get("im.close", Map("channel" -> "D54321", "token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |    "ok": true,
+           |    "no_op": true,
+           |    "already_closed": true
+           |}
+         """.stripMargin))
+
+      when(mockHttpClient.get("im.history", Map("channel" -> "C12345", "token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |    "ok": true,
+           |    "latest": "1358547726.000003",
+           |    "messages": [
+           |        {
+           |            "type": "message",
+           |            "ts": "1358546515.000008",
+           |            "user": "U2147483896",
+           |            "text": "Hello"
+           |        },
+           |        {
+           |            "type": "message",
+           |            "ts": "1358546515.000007",
+           |            "user": "U2147483896",
+           |            "text": "World",
+           |            "is_starred": true
+           |        },
+           |        {
+           |            "type": "something_else",
+           |            "ts": "1358546515.000007",
+           |            "wibblr": true
+           |        }
+           |    ],
+           |    "has_more": true
+           |}
+         """.stripMargin))
+
+      when(mockHttpClient.get("im.history", Map("channel" -> "C12345", "latest" -> "1358546515.000007", "token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |    "ok": true,
+           |    "latest": "1358547726.000003",
+           |    "messages": [
+           |        {
+           |            "type": "message",
+           |            "ts": "1358546515.000008",
+           |            "user": "U2147483896",
+           |            "text": "Hello"
+           |        },
+           |        {
+           |            "type": "message",
+           |            "ts": "1358546515.000007",
+           |            "user": "U2147483896",
+           |            "text": "World",
+           |            "is_starred": true
+           |        }
+           |    ],
+           |    "has_more": false
+           |}
+         """.stripMargin))
+
+      when(mockHttpClient.get("im.list", Map("token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |    "ok": true,
+           |    "ims": [
+           |        {
+           |           "id": "D024BFF1M",
+           |           "is_im": true,
+           |           "user": "USLACKBOT",
+           |           "created": 1372105335,
+           |           "is_user_deleted": false
+           |        },
+           |        {
+           |           "id": "D024BE7RE",
+           |           "is_im": true,
+           |           "user": "U024BE7LH",
+           |           "created": 1356250715,
+           |           "is_user_deleted": false
+           |        }
+           |    ]
+           |}
+         """.stripMargin))
+
+      when(mockHttpClient.get("im.mark", Map("channel" -> "D12345", "ts" -> "1234567890.123456", "token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |    "ok": true
+           |}
+         """.stripMargin))
+
+      when(mockHttpClient.get("im.open", Map("user" -> "U12345", "token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |    "ok": true,
+           |    "channel": {
+           |      "id": "D024BFF1M"
+           |    }
+           |}
+         """.stripMargin))
+
+      when(mockHttpClient.get("im.open", Map("user" -> "U54321", "token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |    "ok": true,
+           |    "no_op": true,
+           |    "already_open": true,
+           |    "channel": {
+           |        "id": "D024BFF1M"
+           |    }
+           |}
+         """.stripMargin))
+
+      im = new IM(mockHttpClient, testApiKey)
+   }
+
+   "IM.close()" should "make a call to im.close and return the response in an IMCloseResponse object" in {
+      val responseOk = im.close("D12345")
+      responseOk.ok shouldBe true
+
+      val responseErr = im.close("D54321")
+      responseErr.ok shouldBe true
+      responseErr.no_op shouldBe true
+      responseErr.already_closed shouldBe true
+   }
+
+   "IM.history()" should "make a call to im.history and return the response in an ChannelHistoryResponse object" in {
+      val response = im.history("C12345")
+
+      response.ok shouldBe true
+      response.hasMore shouldBe true
+      response.isLimited shouldBe false
+      response.messages should have length 3
+
+      val message = response.messages(0)
+
+      message.messageType shouldBe "message"
+      message.ts shouldBe "1358546515.000008"
+      message.user.get shouldBe "U2147483896"
+      message.text.get shouldBe "Hello"
+      message.time.isEqual(new DateTime(2013, 1, 18, 22, 1, 55, DateTimeZone.UTC)) shouldBe true
+
+      verify(mockHttpClient).get("im.history", Map("channel" -> "C12345", "token" -> testApiKey))
+   }
+
+   "IM.historyStream()" should "make repeated calls to im.history and return a stream of messages" in {
+      val messages = im.historyStream("C12345").toList
+
+      messages should have length 5
+
+      verify(mockHttpClient).get("im.history", Map("channel" -> "C12345", "latest" -> "1358546515.000007", "token" -> testApiKey))
+   }
+
+   "IM.list()" should "make a call to im.list and return the response in an IMListResponse object" in {
+      val response = im.list()
+      response.ok shouldBe true
+      response.ims should have length 2
+
+      val im1 = response.ims(0)
+      im1.id shouldBe "D024BFF1M"
+      im1.user shouldBe "USLACKBOT"
+      im1.created shouldBe 1372105335
+      im1.is_user_deleted shouldBe false
+
+      val im2 = response.ims(1)
+      im2.id shouldBe "D024BE7RE"
+      im2.user shouldBe "U024BE7LH"
+      im2.created shouldBe 1356250715
+      im2.is_user_deleted shouldBe false
+   }
+
+   "IM.mark()" should "make a call to im.mark and return the response in an IMMarkResponse object" in {
+      val response = im.mark("D12345", "1234567890.123456")
+      response.ok shouldBe true
+   }
+
+   "IM.open()" should "make a call to im.open and return the response in an IMOpenResponse object" in {
+      val responseOk = im.open("U12345")
+      responseOk.ok shouldBe true
+      responseOk.channelId shouldBe "D024BFF1M"
+      responseOk.no_op shouldBe false
+      responseOk.already_open shouldBe false
+
+      val responseErr = im.open("U54321")
+      responseErr.ok shouldBe true
+      responseErr.channelId shouldBe "D024BFF1M"
+      responseErr.no_op shouldBe true
+      responseErr.already_open shouldBe true
+   }
+}


### PR DESCRIPTION
Added the IM API methods. The im.history interface is the same as channels.history, with the exception of calling im.history instead of channels.history, so I copied that code. Perhaps a cleaner way to do it would be to make the history() functionality a trait, and the history method takes an argument of which API method to call. I decided just to duplicate the code.