### PR TITLE
Updated to v1.1.0 of ScalaJ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ pomExtra := (
 
 libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.0-M1"
 
-libraryDependencies += "org.scalaj" %% "scalaj-http" % "0.3.16"
+libraryDependencies += "org.scalaj" %% "scalaj-http" % "1.1.0"
 
 libraryDependencies += "org.mockito" % "mockito-core" % "1.8.5"
 

--- a/src/main/scala/com/flyberrycapital/slack/HttpClient.scala
+++ b/src/main/scala/com/flyberrycapital/slack/HttpClient.scala
@@ -68,7 +68,7 @@ class HttpClient(BaseURL: String = "https://slack.com/api") {
    def get(method: String, params: Map[String, String]): JsValue = {
       val result = Json.parse(Http(buildURL(method))
          .params(params)
-         .asString)
+         .asString.body)
 
       checkResponse(result)
 
@@ -76,9 +76,10 @@ class HttpClient(BaseURL: String = "https://slack.com/api") {
    }
 
    def post(method: String, data: Map[String, String]): JsValue = {
-      val result = Json.parse(Http.post(buildURL(method))
+      val result = Json.parse(Http(buildURL(method))
+		 .postForm
          .params(data)
-         .asString)
+         .asString.body)
 
       checkResponse(result)
 


### PR DESCRIPTION
The version of ScalaJ used is pretty old, this was a problem in one of my projects.

This PR updates the dependency and the code to be able to use the recent stable version of ScalaJ.

Tests all still pass.