### PR TITLE
Set channel topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ is subject to frequent change._
  - auth.test
  - channels.history
  - channels.list
+ - channels.setTopic
  - chat.delete
  - chat.postMessage
  - chat.update

--- a/src/main/scala/com/flyberrycapital/slack/Methods/Channels.scala
+++ b/src/main/scala/com/flyberrycapital/slack/Methods/Channels.scala
@@ -134,4 +134,21 @@ class Channels(httpClient: HttpClient, apiToken: String) {
 
       ChannelListResponse((responseDict \ "ok").as[Boolean], channels)
    }
+
+   /**
+    * https://api.slack.com/methods/channels.setTopic
+    *
+    * @param channel The channel ID to set topic for
+    * @param topic The topic to set
+    * @param params A map of optional parameters and their values.
+    * @return A ChannelSetTopicResponse object.
+    */
+   def setTopic(channel: String, topic: String, params: Map[String, String] = Map()): ChannelSetTopicResponse = {
+
+      val cleanedParams = params + ("channel" -> channel, "topic" -> topic, "token" -> apiToken)
+
+      val responseDict = httpClient.get("channels.setTopic", cleanedParams)
+
+      ChannelSetTopicResponse((responseDict \ "ok").as[Boolean], (responseDict \ "topic").as[String])
+   }
 }

--- a/src/main/scala/com/flyberrycapital/slack/Responses.scala
+++ b/src/main/scala/com/flyberrycapital/slack/Responses.scala
@@ -37,6 +37,7 @@ object Responses {
    case class ChannelHistoryResponse(ok: Boolean, messages: List[SlackMessage],
                                      hasMore: Boolean, isLimited: Boolean)
    case class ChannelListResponse(ok: Boolean, channels: List[SlackChannel]) extends SlackResponse
+   case class ChannelSetTopicResponse(ok: Boolean, topic: String) extends SlackResponse
    case class IMCloseResponse(ok: Boolean, no_op: Boolean, already_closed: Boolean) extends SlackResponse
    case class IMMarkResponse(ok: Boolean) extends SlackResponse
    case class IMOpenResponse(ok: Boolean, channelId: String, no_op: Boolean, 

--- a/src/test/scala/ChannelsSpec.scala
+++ b/src/test/scala/ChannelsSpec.scala
@@ -185,6 +185,15 @@ class ChannelsSpec extends FlatSpec with MockitoSugar with Matchers with BeforeA
            |}
          """.stripMargin))
 
+      when(mockHttpClient.get("channels.setTopic", Map("channel" -> "C12345", "topic" -> "Test Topic", "token" -> testApiKey)))
+         .thenReturn(Json.parse(
+         """
+           |{
+           |    "ok": true,
+           |    "topic": "Test Topic"
+           |}
+         """.stripMargin))
+
       channels = new Channels(mockHttpClient, testApiKey)
    }
 
@@ -233,6 +242,15 @@ class ChannelsSpec extends FlatSpec with MockitoSugar with Matchers with BeforeA
       (channel.purpose \ "value").as[String] shouldBe "a test channel"
 
       verify(mockHttpClient).get("channels.list", Map("token" -> testApiKey))
+   }
+
+   "Channels.setTopic()" should "make a call to channels.setTopic and return the response in an ChannelSetTopicResponse object" in {
+      val response = channels.setTopic("C12345", "Test Topic")
+
+      response.ok shouldBe true
+      response.topic shouldBe "Test Topic"
+
+      verify(mockHttpClient).get("channels.setTopic", Map("channel" -> "C12345", "topic" -> "Test Topic", "token" -> testApiKey))
    }
 
 }


### PR DESCRIPTION
I've implemented a new method for [setting a channel topic](https://api.slack.com/methods/channels.setTopic), since I want my [bot](https://github.com/sbilinski/slack-lunch-bot) to do this during its lifecycle.

As a side note, I think a new type for representing `channel ID`, would be a nice improvement to this library. Currently, it's quite easy to pass a `name` instead of an `id` and get a `channel_not_found` response. This could be avoided by having a custom type in the `Responses` object or in a companion object for the `Channels` class.

Let me know what you think - I'll gladly implement this change, if it's acceptable for you.